### PR TITLE
Define runt::error::Error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,10 +21,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "backtrace"
+version = "0.3.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1e692897359247cc6bb902933361652380af0f1b7651ae5c5013407f30e109e"
+dependencies = [
+ "backtrace-sys",
+ "cfg-if",
+ "libc",
+ "rustc-demangle",
+]
+
+[[package]]
+name = "backtrace-sys"
+version = "0.1.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7de8aba10a69c8e8d7622c5710229485ec32e9d55fdad160ea559c086fdcd118"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
+
+[[package]]
+name = "cc"
+version = "1.0.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95e28fa049fda1c330bcf9d723be7663a899c4679724b34c81e9f5a326aab8cd"
+
+[[package]]
+name = "cfg-if"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
 name = "clap"
@@ -42,6 +76,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "failure"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8529c2421efa3066a5cbd8063d2244603824daccb6936b079010bb2aa89464b"
+dependencies = [
+ "backtrace",
+ "failure_derive",
+]
+
+[[package]]
+name = "failure_derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "030a733c8287d6213886dd487564ff5c8f6aae10278b3588ed177f9d18f8d231"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
 name = "hermit-abi"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -51,16 +107,108 @@ dependencies = [
 ]
 
 [[package]]
+name = "itoa"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8b7a7c0c47db5545ed3fef7468ee7bb5b74691498139e4b3f6a20685dc6dd8e"
+
+[[package]]
 name = "libc"
 version = "0.2.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dea0c0405123bba743ee3f91f49b1c7cfb684eef0da0a50110f758ccf24cdff0"
 
 [[package]]
+name = "log"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "nix"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50e4785f2c3b7589a0d0c1dd60285e1188adac4006e8abd6dd578e1567027363"
+dependencies = [
+ "bitflags",
+ "cc",
+ "cfg-if",
+ "libc",
+ "void",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df246d292ff63439fea9bc8c0a270bed0e390d5ebd4db4ba15aba81111b5abe3"
+dependencies = [
+ "unicode-xid",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bdc6c187c65bca4260c9011c9e3132efe4909da44726bad24cf7572ae338d7f"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
 name = "runt"
 version = "0.1.0"
 dependencies = [
  "clap",
+ "failure",
+ "log",
+ "nix",
+ "serde",
+ "serde_derive",
+ "serde_json",
+]
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c691c0e608126e00913e33f0ccf3727d5fc84573623b8d65b2df340b5201783"
+
+[[package]]
+name = "ryu"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "535622e6be132bccd223f4bb2b8ac8d53cda3c7a6394944d3b2b33fb974f9d76"
+
+[[package]]
+name = "serde"
+version = "1.0.106"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36df6ac6412072f67cf767ebbde4133a5b2e88e76dc6187fa7104cd16f783399"
+
+[[package]]
+name = "serde_derive"
+version = "1.0.106"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e549e3abf4fb8621bd1609f11dfc9f5e50320802273b12f3811a67e6716ea6c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.51"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da07b57ee2623368351e9a0488bb0b261322a15a6e0ae53e243cbdc0f4208da9"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
@@ -68,6 +216,29 @@ name = "strsim"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
+
+[[package]]
+name = "syn"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0df0eb663f387145cab623dea85b09c2c5b4b0aef44e945d928e682fce71bb03"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67656ea1dc1b41b1451851562ea232ec2e5a80242139f7e679ceccfb5d61f545"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "unicode-xid",
+]
 
 [[package]]
 name = "textwrap"
@@ -85,10 +256,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caaa9d531767d1ff2150b9332433f32a24622147e5ebb1f26409d5da67afd479"
 
 [[package]]
+name = "unicode-xid"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
+
+[[package]]
 name = "vec_map"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
+
+[[package]]
+name = "void"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
 name = "winapi"

--- a/runt/Cargo.toml
+++ b/runt/Cargo.toml
@@ -8,3 +8,9 @@ edition = "2018"
 
 [dependencies]
 clap = "2.33.0"
+log = "0.4"
+nix = "0.17"
+failure = "0.1"
+serde = "1.0"
+serde_json ="1.0"
+serde_derive ="1.0"

--- a/runt/src/error.rs
+++ b/runt/src/error.rs
@@ -1,0 +1,177 @@
+use std::ffi::NulError;
+use std::fmt;
+use std::fmt::Display;
+use std::io::Error as IoError;
+
+use failure::{Backtrace, Context, Fail};
+use log::SetLoggerError;
+use nix::Error as NixError;
+use serde_json::Error as SerdeJSONError;
+
+#[derive(Fail, Debug)]
+pub enum ErrorKind {
+    #[fail(display = "std::io::Error {}", error)]
+    Io { error: IoError },
+    #[fail(display = "nix::Error {}", error)]
+    Nix { error: NixError },
+    #[fail(display = "serde_json::Error {}", error)]
+    SerdeJSON { error: SerdeJSONError },
+    #[fail(display = "fern::InitError {}", error)]
+    Log { error: SetLoggerError },
+    #[fail(display = "OCIError {}", error)]
+    OCI { error: OCIError },
+    #[fail(display = "Null Error")]
+    Null { error: NulError },
+}
+
+#[derive(Debug)]
+pub struct Error {
+    inner: Context<ErrorKind>,
+}
+
+#[derive(Debug)]
+pub struct OCIError {
+    #[allow(dead_code)]
+    kind: OCIErrorKind,
+    #[allow(dead_code)]
+    description: String,
+}
+
+#[derive(Debug)]
+pub enum OCIErrorKind {
+    #[allow(dead_code)]
+    InvaliedStatus,
+}
+
+impl Display for OCIErrorKind {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
+impl OCIError {
+    #[allow(dead_code)]
+    pub fn new(kind: OCIErrorKind, description: &str) -> Self {
+        OCIError {
+            kind,
+            description: description.into(),
+        }
+    }
+
+    #[allow(dead_code)]
+    pub fn context(&self, kind: ErrorKind) -> Context<ErrorKind> {
+        Context::new(kind)
+    }
+}
+
+impl Display for OCIError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "kind: {}, description: {}", self.kind, self.description)
+    }
+}
+
+impl Fail for Error {
+    fn cause(&self) -> Option<&dyn Fail> {
+        self.inner.cause()
+    }
+    fn backtrace(&self) -> Option<&Backtrace> {
+        self.inner.backtrace()
+    }
+}
+
+impl Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        Display::fmt(&self.inner, f)
+    }
+}
+
+impl Error {
+    #[allow(dead_code)]
+    pub fn new(inner: Context<ErrorKind>) -> Error {
+        Error { inner }
+    }
+    #[allow(dead_code)]
+    pub fn kind(&self) -> &ErrorKind {
+        self.inner.get_context()
+    }
+}
+
+impl From<ErrorKind> for Error {
+    fn from(kind: ErrorKind) -> Error {
+        Error {
+            inner: Context::new(kind),
+        }
+    }
+}
+
+impl From<Context<ErrorKind>> for Error {
+    fn from(inner: Context<ErrorKind>) -> Error {
+        Error { inner }
+    }
+}
+
+impl From<IoError> for Error {
+    fn from(error: IoError) -> Error {
+        Error {
+            inner: Context::new(ErrorKind::Io { error }),
+        }
+    }
+}
+
+impl From<NixError> for Error {
+    fn from(error: NixError) -> Error {
+        Error {
+            inner: Context::new(ErrorKind::Nix { error }),
+        }
+    }
+}
+
+impl From<SerdeJSONError> for Error {
+    fn from(error: SerdeJSONError) -> Error {
+        Error {
+            inner: Context::new(ErrorKind::SerdeJSON { error }),
+        }
+    }
+}
+
+impl From<SetLoggerError> for Error {
+    fn from(error: SetLoggerError) -> Error {
+        Error {
+            inner: Context::new(ErrorKind::Log { error }),
+        }
+    }
+}
+
+impl From<OCIError> for Error {
+    fn from(error: OCIError) -> Error {
+        Error {
+            inner: Context::new(ErrorKind::OCI { error }),
+        }
+    }
+}
+
+impl From<NulError> for Error {
+    fn from(error: NulError) -> Error {
+        Error {
+            inner: Context::new(ErrorKind::Null { error }),
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    #[test]
+    fn nixerror_to_error() {
+        let f = || -> Result<(), Error> { Err(nix::Error::invalid_argument().into()) };
+        let _: Error = f().unwrap_err();
+    }
+
+    #[test]
+    fn ocierror_to_error() {
+        let f = || -> Result<(), Error> {
+            Err(OCIError::new(OCIErrorKind::InvaliedStatus, "container must be stopped").into())
+        };
+        let _: Error = f().unwrap_err();
+    }
+}

--- a/runt/src/main.rs
+++ b/runt/src/main.rs
@@ -1,4 +1,5 @@
 mod args;
+mod error;
 mod subcommand;
 
 fn main() {


### PR DESCRIPTION
runt::error::Error includes the following elements.
```rust
std::io::Error
nix::Error
serde_json::Error
log::SetLoggerError
std::ffi::nul
OCIError
```

An `OCIError` occurs when A does not behave as expected in the OCI Runtime Specification.